### PR TITLE
Set TGTRLS parameter for test service programs

### DIFF
--- a/host/iRPGUnit/QBUILD/A_SELFTEST.REXX
+++ b/host/iRPGUnit/QBUILD/A_SELFTEST.REXX
@@ -228,7 +228,7 @@
      "DBGVIEW("_dbgView") ",
      "BNDDIR("_prdLib"/"_bndDir") ",
      "BOPTION(*DUPPROC) ",
-     "DLTSPLF(*YES) "
+     "DLTSPLF(*YES) TGTRLS("TGTRLS")"
 
    return ''
 

--- a/host/iRPGUnit/QCMD/RUCRTRPG.CMD
+++ b/host/iRPGUnit/QCMD/RUCRTRPG.CMD
@@ -182,6 +182,13 @@
                           PMTCTL(*PMTRQS)                    +
                           PROMPT('Pre-Compiler COMPILEOPT')
 
+             PARM       KWD(TGTRLS)                          +
+                          TYPE(*NAME)                        +
+                          PMTCTL(*PMTRQS)                    +
+                          SPCVAL(*CURRENT *PRV)                   +
+                          DFT(*CURRENT)                      +
+                          PROMPT('Target release')
+
  PGM:        QUAL       TYPE(*NAME) LEN(10)
              QUAL       TYPE(*NAME) LEN(10) DFT(*CURLIB) SPCVAL(*CURLIB)     +
                         PROMPT('Library')

--- a/host/iRPGUnit/QINCLUDE/CRTTST.RPGLE
+++ b/host/iRPGUnit/QINCLUDE/CRTTST.RPGLE
@@ -34,6 +34,7 @@
      D  pRpgPpOpt                          const like(RpgPpOpt_t)
      D  pOption                            const likeds(Options_t)
      D  compileopt                 5000a   const varying options(*varsize)
+     D  targetRls                          const like(TargetRelease_t)
 
      D serializeObjectName...
      D                 pr            21a   varying
@@ -82,6 +83,7 @@
      D  export                       10a   const
      D  actGrp                             const like(ActivationGroup_t)
      D  text                               const like(Text_t )
+     D  targetRls                          const like(TargetRelease_t)
 
        //----------------------------------------------------------------------
        //   PRIVATE PROTOTYPES
@@ -151,6 +153,7 @@
      D  bOption                            const likeds(Options_t)
      D  actGrp                             const like(ActivationGroup_t)
      D  text                               const like(Text_t)
+     D  targetRls                          const like(TargetRelease_t)
 
      D deleteModulesAndSpooledFiles...
      D                 pr

--- a/host/iRPGUnit/QINCLUDE/CRTTST.RPGLE
+++ b/host/iRPGUnit/QINCLUDE/CRTTST.RPGLE
@@ -56,6 +56,7 @@
      D  pRpgPpOpt                          const like(RpgPpOpt_t)
      D  pOptions                           const likeds(Options_t)
      D  compileopt                 5000a   const varying options(*varsize)
+     D  targetRls                          const like(TargetRelease_t)
 
      D getCrtCblModCmd...
      D                 pr                        like(Cmd_t)

--- a/host/iRPGUnit/QINCLUDE/TEMPLATES.RPGLE
+++ b/host/iRPGUnit/QINCLUDE/TEMPLATES.RPGLE
@@ -262,6 +262,8 @@
      D                 s            512a   based(template) varying
      D SerializedString_t...
      D                 s           5136a   based(template) varying
+     D TargetRelease_t...
+     D                 s             10a   based(template)
 
        // Program Status Data Structure.
      D sds_t           ds                  based(template) qualified

--- a/host/iRPGUnit/QPNLGRP/RUCRTRPG.PNLGRP
+++ b/host/iRPGUnit/QPNLGRP/RUCRTRPG.PNLGRP
@@ -194,4 +194,11 @@ Refer to the COMPILEOPT parameter in CRTSQLRPGI command help.
 of parameter DBGVIEW is automatically added.
 :ehelp.
 .*
+:help name='RUCRTRPG/TGTRLS' WIDTH=64.
+Target release (TGTRLS) - Help
+:xh3.Target release (TGTRLS)
+:p.
+Refer to the TGTRLS parameter in CRTSRVPGM command help.
+:ehelp.
+.*
 :epnlgrp.

--- a/host/iRPGUnit/QSRC/CRTCBL.RPGLE
+++ b/host/iRPGUnit/QSRC/CRTCBL.RPGLE
@@ -51,6 +51,7 @@
      D  bModules                           const likeds(ObjectArray_t)
      D  pOption                            const likeds(Options_t)
      D  compileOpt                 5000a   const varying options(*varsize)
+     D  targetRls                          const like(TargetRelease_t)
 
      D crtCbl...
      D                 pi
@@ -68,6 +69,7 @@
      D  bModules                           const likeds(ObjectArray_t)
      D  pOption                            const likeds(Options_t)
      D  compileOpt                 5000a   const varying options(*varsize)
+     D  targetRls                          const like(TargetRelease_t)
 
      D srcMbrRslv      s                   like(srcMbr)
      D srcType         s             10a
@@ -88,7 +90,7 @@
 
        crtTst( testPgm : srcFile : srcMbrRslv : text : cOption : dbgView
               : bndSrvPgm : bndDir : bOption : dltSplf : actGrp : bModules
-              : '*N' : pOption : compileOpt );
+              : '*N' : pOption : compileOpt : targetRls);
 
        *inlr = *on;
 

--- a/host/iRPGUnit/QSRC/CRTRPG.RPGLE
+++ b/host/iRPGUnit/QSRC/CRTRPG.RPGLE
@@ -52,6 +52,7 @@
      D  pRpgPpOpt                          const like(RpgPpOpt_t)
      D  pOption                            const likeds(Options_t)
      D  compileOpt                 5000a   const varying options(*varsize)
+     D  targetRls                          const like(TargetRelease_t)
 
      D crtRpg...
      D                 pi
@@ -70,6 +71,7 @@
      D  pRpgPpOpt                          const like(RpgPpOpt_t)
      D  pOption                            const likeds(Options_t)
      D  compileOpt                 5000a   const varying options(*varsize)
+     D  targetRls                          const like(TargetRelease_t)
 
      D srcMbrRslv      s                   like(srcMbr)
      D srcType         s             10a
@@ -90,7 +92,7 @@
 
        crtTst( testPgm : srcFile : srcMbrRslv : text : cOption : dbgView
               : bndSrvPgm : bndDir : bOption : dltSplf : actGrp : bModules
-              : pRpgPpOpt : pOption : compileOpt );
+              : pRpgPpOpt : pOption : compileOpt : targetRls);
 
        *inlr = *on;
 

--- a/host/iRPGUnit/QSRC/CRTTST.RPGLE
+++ b/host/iRPGUnit/QSRC/CRTTST.RPGLE
@@ -204,7 +204,7 @@
            addModule( modules : testPgm : *on); // Add to position #1.
            // QDEVTOOLS/QLNCMSG RNS9305 - Module &1 placed in library &2.
            crtRpgMod( testPgm : qSrcFile : srcMbr : cOption : dbgView :
-                      pRpgPpOpt : pOption : compileopt );
+                      pRpgPpOpt : pOption : compileopt : targetRls);
            modulesCreated = getCreatedModulesFromJobLog(
                               MOD_CRT_RPG : startCompileTime );
            addModules( modules : modulesCreated );
@@ -440,6 +440,7 @@
      D  pRpgPpOpt                          const like(RpgPpOpt_t)
      D  pOption                            const likeds(Options_t)
      D  compileopt                 5000a   const varying options(*varsize)
+     D  targetRls                          const like(TargetRelease_t)
 
       // A command to be executed.
      D cmd             s                   like(Cmd_t)
@@ -447,7 +448,7 @@
       /free
 
          cmd = getCrtRpgModCmd( testPgm : srcFile : srcMbr : cOption : dbgView:
-                                pRpgPpOpt : pOption : compileopt );
+                                pRpgPpOpt : pOption : compileopt : targetRls );
          sndInfoMsg( cmd );
          qcmdexc( cmd : %len(cmd) );
 
@@ -670,6 +671,7 @@
      D  pRpgPpOpt                          const like(RpgPpOpt_t)
      D  pOptions                           const likeds(Options_t)
      D  compileopt                 5000a   const varying options(*varsize)
+     D  targetRls                          const like(TargetRelease_t)
 
       // Command string accumulator.
      D cmd             s                   like(Cmd_t)
@@ -685,6 +687,7 @@
             cmd += 'SRCFILE(' + serializeObjectName( srcFile ) + ') ';
             cmd += serializeValue( 'SRCMBR' : srcMbr );
             cmd += serializeOptions( 'OPTION' : cOptions );
+            cmd += serializeValue( 'TGTRLS' : targetRls );
             cmd += serializeValue( 'DBGVIEW' : dbgView );
 
           // SQLRPGLE
@@ -694,6 +697,7 @@
             cmd += serializeValue( 'SRCMBR' : srcMbr );
             cmd += serializeOptions( 'OPTION' : pOptions );
             cmd += serializeValue('OBJTYPE': '*MODULE');
+            cmd += serializeValue( 'TGTRLS' : targetRls );
             cmd += serializeValue( 'DBGVIEW' : '*NONE');
 
             if (pRpgPpOpt <> '*DEFAULT');

--- a/host/iRPGUnit/QSRC/CRTTST.RPGLE
+++ b/host/iRPGUnit/QSRC/CRTTST.RPGLE
@@ -111,6 +111,7 @@
      D  pRpgPpOpt                          const like(RpgPpOpt_t)
      D  pOption                            const likeds(Options_t)
      D  compileopt                 5000a   const varying options(*varsize)
+     D  targetRls                          const like(TargetRelease_t)
 
      D modules         ds                  likeds(bModules) inz
      D srcType         s             10a   varying
@@ -222,7 +223,7 @@
 
          srvPgm = crtSrvPgm(
                      testPgm : bndSrvPgm : bndDir : modules : bOption :
-                     actGrp : textRslv);
+                     actGrp : textRslv : targetRls);
 
          tagTstSrvPgm(srvPgm : qSrcFile : srcMbr);
 
@@ -547,6 +548,7 @@
      D  bOption                            const likeds(Options_t)
      D  actGrp                             const like(ActivationGroup_t)
      D  text                               const like(Text_t)
+     D  targetRls                          const like(TargetRelease_t)
 
       // Export all procedures from the service program.
      D EXPORT_ALL      c                   const('*ALL')
@@ -574,7 +576,8 @@
                                 bOption :
                                 EXPORT_ALL :
                                 actGrp :
-                                text );
+                                text :
+                                targetRls );
          sndInfoMsg( cmd );
          qcmdexc( cmd : %len(cmd) );
 
@@ -598,6 +601,7 @@
      D  export                             const like(Export_t)
      D  actGrp                             const like(ActivationGroup_t)
      D  text                               const like(Text_t )
+     D  targetRls                          const like(TargetRelease_t)
 
       // Command string accumulator.
      D cmd             s                   like(Cmd_t)
@@ -611,6 +615,7 @@
         cmd += serializeOptions( 'OPTION' : options );
         cmd += serializeValue( 'ACTGRP' : actGrp );
         cmd += serializeString( 'TEXT' : text );
+        cmd += serializeValue( 'TGTRLS' : targetRls );
         cmd += serializeString( 'DETAIL' : '*BASIC' );
 
         if export <> *blank;

--- a/host/iRPGUnit/QUNITTEST/CRTTSTT.RPGLE
+++ b/host/iRPGUnit/QUNITTEST/CRTTSTT.RPGLE
@@ -195,7 +195,8 @@
                                         noDbgView :
                                         rpgPpOptLvl2 :
                                         noPOption :
-                                        noCompileOpt );
+                                        noCompileOpt :
+                                        noTargetRls );
         aEqual( 'CRTRPGMOD MODULE(*CURLIB/SYSTYPES) '
               + 'SRCFILE(QSYSINC/QRPGLESRC) SRCMBR(SYSTYPES)' : crtRpgModCmd );
 
@@ -221,7 +222,8 @@
                                         noDbgView :
                                         rpgPpOptLvl2 :
                                         noPOption :
-                                        noCompileOpt );
+                                        noCompileOpt :
+                                        noTargetRls );
         aEqual( 'CRTRPGMOD MODULE(*CURLIB/SYSTYPES) '
               + 'SRCFILE(QSYSINC/QRPGLESRC) SRCMBR(SYSTYPES) '
               + 'OPTION(*SRCSTMT)' : crtRpgModCmd );
@@ -249,7 +251,8 @@
                                         noDbgView :
                                         rpgPpOptLvl2 :
                                         noPOption :
-                                        noCompileOpt );
+                                        noCompileOpt :
+                                        noTargetRls );
         aEqual( 'CRTRPGMOD MODULE(*CURLIB/SYSTYPES) '
               + 'SRCFILE(QSYSINC/QRPGLESRC) SRCMBR(SYSTYPES) '
               + 'OPTION(*SRCSTMT *NODEBUGIO)' : crtRpgModCmd );
@@ -269,7 +272,8 @@
                                         '*LIST'   :
                                         rpgPpOptLvl2 :
                                         noPOption :
-                                        noCompileOpt );
+                                        noCompileOpt :
+                                        noTargetRls );
         aEqual( 'CRTRPGMOD MODULE(*CURLIB/SYSTYPES) '
               + 'SRCFILE(QSYSINC/QRPGLESRC) SRCMBR(SYSTYPES) '
               + 'DBGVIEW(*LIST)' : crtRpgModCmd );
@@ -277,6 +281,27 @@
       /end-free
      P                 e
 
+     PtestModTargetRls...
+     P                 b                   export
+     D                 pi
+     D
+      /free
+
+        crtRpgModCmd = getCrtRpgModCmd( 'SYSTYPES  *CURLIB   ' :
+                                        'QRPGLESRC QSYSINC   ' :
+                                        'SYSTYPES'  :
+                                        noCOption :
+                                        '*LIST'   :
+                                        rpgPpOptLvl2 :
+                                        noPOption :
+                                        noCompileOpt :
+                                        '*CURRENT' );
+        aEqual( 'CRTRPGMOD MODULE(*CURLIB/SYSTYPES) '
+              + 'SRCFILE(QSYSINC/QRPGLESRC) SRCMBR(SYSTYPES) '
+              + 'DBGVIEW(*LIST) TGTRLS(*CURRENT)' : crtRpgModCmd );
+
+      /end-free
+     P                 e
 
      PtestOneBndSrvPgm...
      P                 b                   export

--- a/host/iRPGUnit/QUNITTEST/CRTTSTT.RPGLE
+++ b/host/iRPGUnit/QUNITTEST/CRTTSTT.RPGLE
@@ -122,6 +122,8 @@
      D noCompileOpt    s              1a   varying
        // No activation group.
      D noActGrp        s             10a   varying
+       // No target release
+     D noTargetRls     s                   like(TargetRelease_t)
 
        // Command to create an RPG module.
      D crtRpgModCmd    s            256a
@@ -300,7 +302,8 @@
                                         noBOption :
                                         noExport :
                                         noActGrp :
-                                        noText );
+                                        noText :
+                                        noTargetRls);
 
         // Control.
 
@@ -338,7 +341,8 @@
                                         noBOption :
                                         noExport :
                                         noActGrp :
-                                        noText );
+                                        noText :
+                                        noTargetRls);
 
         // Control.
 
@@ -374,7 +378,8 @@
                                         noBOption :
                                         noExport :
                                         noActGrp :
-                                        noText );
+                                        noText :
+                                        noTargetRls);
 
         // Control.
 
@@ -410,7 +415,8 @@
                                         noBOption :
                                         noExport :
                                         noActGrp :
-                                        noText );
+                                        noText :
+                                        noTargetRls);
 
         // Control.
 
@@ -445,7 +451,8 @@
                                         oneBOption :
                                         noExport :
                                         noActGrp :
-                                        noText );
+                                        noText :
+                                        noTargetRls);
 
         // Control.
 
@@ -478,7 +485,8 @@
                                         noBOption :
                                         export :
                                         noActGrp :
-                                        noText );
+                                        noText :
+                                        noTargetRls);
 
         // Control.
 
@@ -511,7 +519,8 @@
                                         noBOption :
                                         noExport :
                                         actGrp :
-                                        noText );
+                                        noText :
+                                        noTargetRls);
 
         // Control.
 
@@ -522,6 +531,38 @@
       /end-free
      P                 e
 
+     PtestTargetRls    b                   export
+     D                 pi
+
+       // Export option.
+     D targetRls       s                   like(TargetRelease_t)
+
+      /free
+
+        // Setup.
+
+        targetRls = '*CURRENT';
+
+        // Execute.
+
+        crtSrvPgmCmd = getCrtSrvPgmCmd( 'PGM_NAME  *CURLIB   ' :
+                                        noBndSrvPgm :
+                                        noBndDir :
+                                        noModule :
+                                        noBOption :
+                                        noExport :
+                                        noActGrp :
+                                        noText :
+                                        targetRls);
+
+        // Control.
+
+        aEqual( 'CRTSRVPGM SRVPGM(*CURLIB/PGM_NAME) '
+              + 'DETAIL(''*BASIC'') TGTRLS(*CURRENT)'
+              : crtSrvPgmCmd );
+
+      /end-free
+     P                 e
 
      PtestText         b                   export
      D                 pi
@@ -544,7 +585,8 @@
                                         noBOption :
                                         noExport :
                                         noActGrp :
-                                        text );
+                                        text :
+                                        noTargetRls);
 
         // Control.
 


### PR DESCRIPTION
Set TGTRLS parameter for test service programs to be the same as on modules. This solves an issue on LPARs where *PRV is set by default for CRTSRVPGM command.