### PR TITLE
Added universal assertion method utilizing options(*convert)

### DIFF
--- a/host/iRPGUnit/QBND/RUTESTCASE.BND
+++ b/host/iRPGUnit/QBND/RUTESTCASE.BND
@@ -55,7 +55,7 @@ STRPGMEXP  PGMLVL(*CURRENT) SIGNATURE('iRPGUNIT V3.3')
   EXPORT SYMBOL("assertMessageQueueContains")  /* public API */
 
   EXPORT SYMBOL("ASSERT_registerStartPgm")     /* internally used procedure */
-
+  EXPORT SYMBOL("uEqual")                      /* public API */
 ENDPGMEXP
 
 STRPGMEXP  PGMLVL(*PRV) SIGNATURE('iRPGUNIT V3.0')

--- a/host/iRPGUnit/QINCLUDE/TESTCASE.RPGLE
+++ b/host/iRPGUnit/QINCLUDE/TESTCASE.RPGLE
@@ -67,7 +67,28 @@
      D  actual                       31s 0 const
      D  fieldName                    64a   const varying options(*nopass: *omit)
 
-
+      /if defined(*V7R4M0)
+      // uEqual -- Universal Equality Assertion
+      //
+      // Compares the given values converted to string, expected and actual.
+      // The assertion fails, if both values are different.
+      //
+      // Example:
+      //   uEqual( *ON : isFound );
+      //   uEqual( 123 : 123 );
+      //   uEqual(D'2024-09-10', %date());
+      //
+      // Message:
+      //   Expected 'expected', but was 'actual'.
+      //
+      // If parameter 'fieldName' is specified, the message is prefixed
+      // with 'fieldName:'.
+     D uEqual          pr                  extproc('uEqual')
+     D                                     opdesc
+     D  expected                       *   const options(*convert)
+     D  actual                         *   const options(*convert)
+     D  fieldName                    64a   const varying options(*nopass: *omit)
+      /endif
       // nEqual -- Boolean Equality Assertion
       //
       // Compares the given Boolean values expected and actual. The assertion fails,

--- a/host/iRPGUnit/QSRC/ASSERT.RPGLE
+++ b/host/iRPGUnit/QSRC/ASSERT.RPGLE
@@ -112,6 +112,8 @@
      D                 c                   'iEqual'
      D START_PROC_NEQUAL...
      D                 c                   'nEqual'
+     D START_PROC_UEQUAL...
+     D                 c                   'uEqual'
      D START_PROC_ASSERT...
      D                 c                   'assert'
      D START_PROC_FAIL...
@@ -276,7 +278,43 @@
 
       /end-free
      P                 e
+      /if defined(*V7R4M0)
+     P uEqual...
+     P                 b                   export
+     D                 pi                  opdesc
+     D  expected                       *   const options(*convert)
+     D  actual                         *   const options(*convert)
+     D  fieldName                    64a   const varying options(*nopass: *omit)
 
+     D msg             s                   like(msgText_t) inz
+
+      /free
+       if (%parms() >= 3 and %addr(fieldName) <> *NULL);
+         msg = %trim(fieldName) + ': ';
+       endif;
+
+       msg = msg
+           + 'Expected ' + QUOTE + %str(expected) + QUOTE + ','
+           + ' but was ' + QUOTE + %str(actual)   + QUOTE + '.';
+       doAssert(%str(expected) = %str(actual) : msg
+                : ONE_CALL_STK_LVL_ABOVE : START_PROC_UEQUAL);
+
+      /end-free
+     P                 e
+      /else
+     P uEqual...
+     P                 b                   export
+     D                 pi                  opdesc extproc('uEqual')
+     D  expected                       *   const options(*string)
+     D  actual                         *   const options(*string)
+     D  fieldName                    64a   const varying options(*nopass: *omit)
+     D msg             s                   like(msgText_t) inz
+      /free
+       msg = 'Method unsupported in current target release';
+       fail(msg);
+      /end-free
+     P                 e
+      /endif
        //----------------------------------------------------------------------
        // Assert equality between two alphanumeric variables.
        //----------------------------------------------------------------------

--- a/host/iRPGUnit/QUNITTEST/ASSERTT.RPGLE
+++ b/host/iRPGUnit/QUNITTEST/ASSERTT.RPGLE
@@ -430,7 +430,342 @@
       /end-free
      P                 e
 
+      /if defined(*V7R4M0)
+     P testUniversalStringComparisonWithSuccess...
+     P                 b                   export
+      /free
+        uEqual('abc' : 'abc');
 
+        aEqual( EMPTY_ASSERT_FAIL_EVT : getAssertFailEvt() );
+      /end-free
+     P                 e
+
+     P testUniversalNumericComparisonWithSuccess...
+     P                 b                   export
+      /free
+        uEqual(123 : 123);
+
+        aEqual( EMPTY_ASSERT_FAIL_EVT : getAssertFailEvt() );
+      /end-free
+     P                 e
+
+     P testUniversalTimestampComparisonWithSuccess...
+     P                 b                   export
+     D tstmp1          s               z   inz(z'2024-09-02-11.22.33.123456')
+     D tstmp2          s               z   inz(z'2024-09-02-11.22.33.123456')
+      /free
+        uEqual(tstmp1 : tstmp2);
+
+        aEqual( EMPTY_ASSERT_FAIL_EVT : getAssertFailEvt() );
+      /end-free
+     P                 e
+
+     P testUniversalTimeComparisonWithSuccess...
+     P                 b                   export
+     D tm1             s               t   inz(t'11.22.33')
+     D tm2             S               t   inz(t'11.22.33')
+      /free
+        uEqual(tm1 : tm2);
+
+        aEqual( EMPTY_ASSERT_FAIL_EVT : getAssertFailEvt() );
+      /end-free
+     P                 e
+
+     P testUniversalDateComparisonWithSuccess...
+     P                 b                   export
+     D dt1             s               d   inz(d'2024-09-02')
+     D dt2             s               d   inz(d'2024-09-02')
+      /free
+        uEqual(dt1 : dt2);
+
+        aEqual( EMPTY_ASSERT_FAIL_EVT : getAssertFailEvt() );
+      /end-free
+     P                 e
+
+     PtestUniversalStringComparisonWithFailure...
+     P                 b                   export
+     D                 pi
+     D                                     extproc('testUniversalStringComparis-
+     D                                     onWithFailure')
+
+     D excpWasSeen     s               n
+     D assertFailEvt   ds                  likeds(AssertFailEvt_t)
+
+      /free
+
+        // Execution.
+
+        monitor;
+          uEqual( 'Hello' : 'Good bye' );
+          excpWasSeen = *off;
+
+        on-error;
+          excpWasSeen = *on;
+        endmon;
+
+        // Controls.
+
+        assertFailEvt = getAssertFailEvt();
+
+        assert( excpWasSeen :
+                'uEqual( Hello : Good bye )'
+              + ' should have raised an error message.' );
+
+        aEqual( 'Expected ''Hello'', but was ''Good bye''.' :
+                assertFailEvt.msg );
+
+        aEqual( 'ASSERTT'    : assertFailEvt.callStk.Entry(1).qStmt.qPgm.nm );
+        aEqual( 'ASSERTT'    : assertFailEvt.callStk.Entry(1).qStmt.qMod.nm );
+        aEqual( %proc        : assertFailEvt.callStk.Entry(1).qStmt.procNm );
+
+        monitor;
+          aEqual( '499'     : assertFailEvt.callStk.Entry(1).qStmt.specNb );  // IFS Compile
+        on-error;
+          aEqual( '49900'   : assertFailEvt.callStk.Entry(1).qStmt.specNb );  // QSYS Compile
+        endmon;
+
+      /end-free
+     P                 e
+
+     PtestUniversalNumberComparisonWithFailure...
+     P                 b                   export
+     D                 pi
+     D                                     extproc('testUniversalNumberComparis-
+     D                                     onWithFailure')
+
+     D excpWasSeen     s               n
+     D assertFailEvt   ds                  likeds(AssertFailEvt_t)
+
+      /free
+
+        // Execution.
+
+        monitor;
+          uEqual( 123 : 321 );
+          excpWasSeen = *off;
+
+        on-error;
+          excpWasSeen = *on;
+        endmon;
+
+        // Controls.
+
+        assertFailEvt = getAssertFailEvt();
+
+        assert( excpWasSeen :
+                'uEqual( 123 : 321 ) should have raised an error message.' );
+
+        aEqual( 'Expected ''123'', but was ''321''.' :
+                assertFailEvt.msg );
+
+        aEqual( 'ASSERTT'    : assertFailEvt.callStk.Entry(1).qStmt.qPgm.nm );
+        aEqual( 'ASSERTT'    : assertFailEvt.callStk.Entry(1).qStmt.qMod.nm );
+        aEqual( %proc        : assertFailEvt.callStk.Entry(1).qStmt.procNm );
+
+        monitor;
+          aEqual( '544'     : assertFailEvt.callStk.Entry(1).qStmt.specNb );  // IFS Compile
+        on-error;
+          aEqual( '54400'   : assertFailEvt.callStk.Entry(1).qStmt.specNb );  // QSYS Compile
+        endmon;
+
+      /end-free
+     P                 e
+
+     PtestUniversalTimestampComparisonWithFailure...
+     P                 b                   export
+     D                 pi
+     D                                     extproc('testUniversalTimestampCompa-
+     D                                     risonWithFailure')
+
+     D excpWasSeen     s               n
+     D assertFailEvt   ds                  likeds(AssertFailEvt_t)
+     D tstmp1          s               z   inz(z'2024-09-02-11.22.33.123456')
+     D tstmp2          s               z   inz(z'2024-11-03-22.11.00.654321')
+      /free
+
+        // Execution.
+
+        monitor;
+          uEqual( tstmp1: tstmp2 );
+          excpWasSeen = *off;
+
+        on-error;
+          excpWasSeen = *on;
+        endmon;
+
+        // Controls.
+
+        assertFailEvt = getAssertFailEvt();
+
+        assert( excpWasSeen :
+                'uEqual( ''2024-09-02-11.22.33.123456'' : +
+                ''2024-11-03-22.11.00.654321'' )' +
+                ' should have raised an error message.' );
+
+        aEqual( 'Expected ''2024-09-02-11.22.33.123456'', ' +
+                'but was ''2024-11-03-22.11.00.654321''.' :
+                assertFailEvt.msg );
+
+        aEqual( 'ASSERTT'    : assertFailEvt.callStk.Entry(1).qStmt.qPgm.nm );
+        aEqual( 'ASSERTT'    : assertFailEvt.callStk.Entry(1).qStmt.qMod.nm );
+        aEqual( %proc        : assertFailEvt.callStk.Entry(1).qStmt.procNm );
+
+        monitor;
+          aEqual( '589'     : assertFailEvt.callStk.Entry(1).qStmt.specNb );  // IFS Compile
+        on-error;
+          aEqual( '58900'   : assertFailEvt.callStk.Entry(1).qStmt.specNb );  // QSYS Compile
+        endmon;
+
+      /end-free
+     P                 e
+
+     PtestUniversalDateComparisonWithFailure...
+     P                 b                   export
+     D                 pi
+     D                                     extproc('testUniversalDateCompa-
+     D                                     risonWithFailure')
+
+     D excpWasSeen     s               n
+     D assertFailEvt   ds                  likeds(AssertFailEvt_t)
+     D dt1             s               d   inz(d'2024-11-02')
+     D dt2             s               d   inz(d'2011-09-02')
+      /free
+
+        // Execution.
+
+        monitor;
+          uEqual( dt1 : dt2 );
+          excpWasSeen = *off;
+
+        on-error;
+          excpWasSeen = *on;
+        endmon;
+
+        // Controls.
+
+        assertFailEvt = getAssertFailEvt();
+
+        assert( excpWasSeen :
+                'uEqual( ''2024-11-02'' : + ''2011-09-02'' )' +
+                ' should have raised an error message.' );
+
+        aEqual( 'Expected ''2024-11-02'', but was ''2011-09-02''.' :
+                assertFailEvt.msg );
+
+        aEqual( 'ASSERTT'    : assertFailEvt.callStk.Entry(1).qStmt.qPgm.nm );
+        aEqual( 'ASSERTT'    : assertFailEvt.callStk.Entry(1).qStmt.qMod.nm );
+        aEqual( %proc        : assertFailEvt.callStk.Entry(1).qStmt.procNm );
+
+        monitor;
+          aEqual( '637'     : assertFailEvt.callStk.Entry(1).qStmt.specNb );  // IFS Compile
+        on-error;
+          aEqual( '63700'   : assertFailEvt.callStk.Entry(1).qStmt.specNb );  // QSYS Compile
+        endmon;
+
+      /end-free
+     P                 e
+
+     PtestUniversalTimeComparisonWithFailure...
+     P                 b                   export
+     D                 pi
+     D                                     extproc('testUniversalTimeCompa-
+     D                                     risonWithFailure')
+
+     D excpWasSeen     s               n
+     D assertFailEvt   ds                  likeds(AssertFailEvt_t)
+     D tm1             s               t   inz(t'11.22.33')
+     D tm2             S               t   inz(t'22.33.11')
+      /free
+
+        // Execution.
+
+        monitor;
+          uEqual( tm1 : tm2 );
+          excpWasSeen = *off;
+
+        on-error;
+          excpWasSeen = *on;
+        endmon;
+
+        // Controls.
+
+        assertFailEvt = getAssertFailEvt();
+
+        assert( excpWasSeen :
+                'uEqual( ''11.22.33'' : + ''22.33.11'' )' +
+                ' should have raised an error message.' );
+
+        aEqual( 'Expected ''11.22.33'', but was ''22.33.11''.' :
+                assertFailEvt.msg );
+
+        aEqual( 'ASSERTT'    : assertFailEvt.callStk.Entry(1).qStmt.qPgm.nm );
+        aEqual( 'ASSERTT'    : assertFailEvt.callStk.Entry(1).qStmt.qMod.nm );
+        aEqual( %proc        : assertFailEvt.callStk.Entry(1).qStmt.procNm );
+
+        monitor;
+          aEqual( '683'     : assertFailEvt.callStk.Entry(1).qStmt.specNb );  // IFS Compile
+        on-error;
+          aEqual( '68300'   : assertFailEvt.callStk.Entry(1).qStmt.specNb );  // QSYS Compile
+        endmon;
+
+      /end-free
+     P                 e
+     P testUniversaBooleanComparisonWithSuccess...
+     P                 b                   export
+     D n1              s               n   inz(*on)
+     D n2              s               n   inz(*on)
+      /free
+        uEqual(n1: n2);
+
+        aEqual( EMPTY_ASSERT_FAIL_EVT : getAssertFailEvt() );
+      /end-free
+     P                 e
+     P testUniversaBooleanComparisonWithFailure...
+     P                 b                   export
+     D                 pi
+     D                                     extproc('testUniversalBooleanCompa-
+     D                                     risonWithFailure')
+
+     D excpWasSeen     s               n
+     D assertFailEvt   ds                  likeds(AssertFailEvt_t)
+     D n1              s               n   inz(*off)
+     D n2              s               n   inz(*on)
+      /free
+
+        // Execution.
+
+        monitor;
+          uEqual( n1 : n2 );
+          excpWasSeen = *off;
+
+        on-error;
+          excpWasSeen = *on;
+        endmon;
+
+        // Controls.
+
+        assertFailEvt = getAssertFailEvt();
+
+        assert( excpWasSeen :
+                'uEqual( ''0'' : + ''1'' )' +
+                ' should have raised an error message.' );
+
+        aEqual( 'Expected ''0'', but was ''1''.' :
+                assertFailEvt.msg );
+
+        aEqual( 'ASSERTT'    : assertFailEvt.callStk.Entry(1).qStmt.qPgm.nm );
+        aEqual( 'ASSERTT'    : assertFailEvt.callStk.Entry(1).qStmt.qMod.nm );
+        aEqual( %proc        : assertFailEvt.callStk.Entry(1).qStmt.procNm );
+
+        monitor;
+          aEqual( '738'     : assertFailEvt.callStk.Entry(1).qStmt.specNb );  // IFS Compile
+        on-error;
+          aEqual( '73800'   : assertFailEvt.callStk.Entry(1).qStmt.specNb );  // QSYS Compile
+        endmon;
+
+      /end-free
+     P                 e
+      /endif
       //----------------------------------------------------------------------
       //   Procedure that simulates the test case executor procedure
       //   of module CMDRUNSRV. It must receive the message sent by fail().


### PR DESCRIPTION
I have added an **uEqual** assertion which utilizes **options(***convert)** introduced in December 2022. It requires 7.4 or 7.5 with proper PTFs installed. Not a big deal, but I think it would be nice to have it anyway. I named the method as **uEqual**, but maybe simple **equal** would be better. Let me know what you think.