### PR TITLE
Add workflow to create github release with SAVF

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,3 @@
-
 name: Release
 
 on:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,21 @@
+
+name: Release
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            docs/update-site/eclipse/rdi8.0/Server/RPGUNIT.SAVF

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,5 +17,6 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
+          generate_release_notes: true
           files: |
             docs/update-site/eclipse/rdi8.0/Server/RPGUNIT.SAVF


### PR DESCRIPTION
This PR adds a workflow to create a GitHub release when a tag is created. This release will include the `RPGUNIT.SAVF` file as an asset. The 3-digit parts for the tag do not need to be used as discussed [here](https://github.com/IBM/vscode-ibmi-testing/issues/5#issuecomment-2786817087).

For reference: https://github.com/SanjulaGanepola/irpgunit/releases